### PR TITLE
Assign parent to dialogs

### DIFF
--- a/src/main/java/com/tibagni/logviewer/LogViewerApplication.java
+++ b/src/main/java/com/tibagni/logviewer/LogViewerApplication.java
@@ -8,7 +8,7 @@ public class LogViewerApplication {
 
   public static void main(String[] args) {
     JFrame frame = new JFrame(APPLICATION_NAME);
-    LogViewerView logViewer = new LogViewerView();
+    LogViewerView logViewer = new LogViewerView(frame);
 
     frame.setContentPane(logViewer.getContentPane());
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);

--- a/src/main/java/com/tibagni/logviewer/LogViewerView.java
+++ b/src/main/java/com/tibagni/logviewer/LogViewerView.java
@@ -12,6 +12,7 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.filechooser.FileSystemView;
+import java.awt.Frame;
 import java.awt.event.*;
 import java.util.stream.IntStream;
 
@@ -34,8 +35,10 @@ public class LogViewerView implements LogViewer.View {
 
   private LogListTableModel logListTableModel;
   private LogListTableModel filteredLogListTableModel;
+  private Frame parent;
 
-  public LogViewerView() {
+  public LogViewerView(Frame parent) {
+    this.parent = parent;
     presenter = new LogViewerPresenter(this);
     logFileChooser = new JFileChooserExt(FileSystemView.getFileSystemView().getHomeDirectory());
     filterFileChooser = new JFileChooserExt(FileSystemView.getFileSystemView().getHomeDirectory());
@@ -178,13 +181,13 @@ public class LogViewerView implements LogViewer.View {
   private void editSelectedFilter() {
     if (filtersList.getSelectedIndices().length == 1) {
       // We don't care about the return value here
-      EditFilterDialog.showEditFilterDialog(addNewFilterBtn,
+      EditFilterDialog.showEditFilterDialog(parent, addNewFilterBtn,
           filtersList.getModel().getElementAt(filtersList.getSelectedIndex()));
     }
   }
 
   private void addFilter() {
-    Filter newFilter = EditFilterDialog.showEditFilterDialog(addNewFilterBtn);
+    Filter newFilter = EditFilterDialog.showEditFilterDialog(parent, addNewFilterBtn);
     if (newFilter != null) {
       presenter.addFilter(newFilter);
     }

--- a/src/main/java/com/tibagni/logviewer/filter/EditFilterDialog.java
+++ b/src/main/java/com/tibagni/logviewer/filter/EditFilterDialog.java
@@ -44,7 +44,8 @@ public class EditFilterDialog extends JDialog {
     }
   };
 
-  private EditFilterDialog(Filter editingFilter) {
+  private EditFilterDialog(Frame owner, Filter editingFilter) {
+    super(owner);
     setSelectedColor(Color.RED); // Set RED by default
 
     setContentPane(contentPane);
@@ -131,7 +132,7 @@ public class EditFilterDialog extends JDialog {
   }
 
   private void onEditRegex() {
-    RegexEditorDialog.Result edited = RegexEditorDialog.showEditRegexDialog(this,
+    RegexEditorDialog.Result edited = RegexEditorDialog.showEditRegexDialog(this, this,
         regexTxt.getText(), caseSensitiveCbx.isSelected());
 
     if (edited != null) {
@@ -146,8 +147,8 @@ public class EditFilterDialog extends JDialog {
     colorPreview.invalidate();
   }
 
-  public static Filter showEditFilterDialog(Component relativeTo, Filter editingFilter) {
-    EditFilterDialog dialog = new EditFilterDialog(editingFilter);
+  public static Filter showEditFilterDialog(Frame parent, Component relativeTo, Filter editingFilter) {
+    EditFilterDialog dialog = new EditFilterDialog(parent, editingFilter);
     dialog.setLocationRelativeTo(relativeTo);
     dialog.pack();
     dialog.setVisible(true);
@@ -155,7 +156,7 @@ public class EditFilterDialog extends JDialog {
     return dialog.filter;
   }
 
-  public static Filter showEditFilterDialog(Component relativeTo) {
-    return showEditFilterDialog(relativeTo, null);
+  public static Filter showEditFilterDialog(Frame parent, Component relativeTo) {
+    return showEditFilterDialog(parent, relativeTo, null);
   }
 }

--- a/src/main/java/com/tibagni/logviewer/filter/regex/RegexEditorDialog.java
+++ b/src/main/java/com/tibagni/logviewer/filter/regex/RegexEditorDialog.java
@@ -27,7 +27,8 @@ public class RegexEditorDialog extends JDialog {
   boolean isRegexValid;
   Result result;
 
-  private RegexEditorDialog() {
+  private RegexEditorDialog(Dialog owner) {
+    super(owner);
     setContentPane(contentPane);
     setModal(true);
     getRootPane().setDefaultButton(buttonOK);
@@ -114,8 +115,8 @@ public class RegexEditorDialog extends JDialog {
     }
   }
 
-  public static Result showEditRegexDialog(Component relativeTo, String pattern, boolean caseSensitive) {
-    RegexEditorDialog dialog = new RegexEditorDialog();
+  public static Result showEditRegexDialog(Dialog parent, Component relativeTo, String pattern, boolean caseSensitive) {
+    RegexEditorDialog dialog = new RegexEditorDialog(parent);
     dialog.caseSensitive.setSelected(caseSensitive);
     dialog.regexEdit.setText(pattern);
     dialog.applyRegexToPreview();


### PR DESCRIPTION
When a dialog is displayed, if the user moves the parent dialog, the new
dialog isn't moved as well, as if they were two independent windows. By
assigning a parent to the dialogs, they become visually related.

Signed-off-by: Crístian Deives <cristiandeives@gmail.com>