### PR TITLE
Don't remove filter when cancelling confirmation dialog

### DIFF
--- a/src/main/java/com/tibagni/logviewer/LogViewerView.java
+++ b/src/main/java/com/tibagni/logviewer/LogViewerView.java
@@ -202,7 +202,7 @@ public class LogViewerView implements LogViewer.View {
         JOptionPane.YES_NO_OPTION,
         JOptionPane.WARNING_MESSAGE);
 
-    if (userChoice == JOptionPane.NO_OPTION) return;
+    if (userChoice != JOptionPane.YES_OPTION) return;
 
     presenter.removeFilters(filtersList.getSelectedIndices());
   }


### PR DESCRIPTION
When the user cancels the confirmation dialog (e.g. by pressing Esc),
the JOptionPane call returns CANCEL_OPTION. Instead of assuming that
only NO_OPTION is the invalid choice, assume that everything that is not
YES_OPTION is invalid.

Signed-off-by: Crístian Deives <cristiandeives@gmail.com>