### PR TITLE
Fix file extension verification when saving filter

### DIFF
--- a/src/main/java/com/tibagni/logviewer/util/JFileChooserExt.java
+++ b/src/main/java/com/tibagni/logviewer/util/JFileChooserExt.java
@@ -51,7 +51,7 @@ public class JFileChooserExt extends JFileChooser {
   private void setExtensionToSavingFile() {
     File f = getSelectedFile();
     if (f != null && !StringUtils.isEmpty(saveExtension)) {
-      if (!f.getName().endsWith(saveExtension)) {
+      if (!f.getName().endsWith("." + saveExtension)) {
         setSelectedFile(new File(f.getPath() + "." + saveExtension));
       }
     }


### PR DESCRIPTION
If the user saves a filter file with the name "filter", the file will be
called "filter" (not "filter.filter", as expected) and the file won't be
opened easily later due to the lack of the extension.

When checking if the file name already ends with the correct extension,
the program looks for the string "filter" in the end of the file name;
if it exists, it assumes the file already has a valid extension and
doesn't append anything to it. Then, when the user types "filter",
the program doesn't append the extension ".filter" to it.

Check if the file name ends with ".filter" (instead of "filter") when
deciding if an extension should be appended. If the user types "filter",
as it doesn't end with ".filter", an extension will be appended and the
final name will be "filter.filter".

Signed-off-by: Crístian Deives <cristiandeives@gmail.com>