### PR TITLE
Fixes #31: Use system new line sep. in testPersistGroupMultipleFilters

### DIFF
--- a/src/test/java/com/tibagni/logviewer/FiltersRepositoryTests.kt
+++ b/src/test/java/com/tibagni/logviewer/FiltersRepositoryTests.kt
@@ -402,7 +402,7 @@ class FiltersRepositoryTests {
 
     // Check contents of the saved file
     val savedText = temporaryFilterFile[0].inputStream().bufferedReader().readText()
-    val savedFilters = savedText.split("\n")
+    val savedFilters = savedText.split(System.getProperty("line.separator"))
 
     assertNotNull(savedFilters)
     assertEquals(3, savedFilters.size)


### PR DESCRIPTION
The test FiltersRepositoryTests.testPersistGroupMultipleFilters splits
a string by '\n' and checks the result strings. On Windows, the new
line separator is '\r\n', so when the string is split by '\n', it
leaves a '\r' in each line, and the test fails due to that difference.

Split the string by using the new line separator of the current
system, instead of always using '\n', which isn't the separator
on Windows.