### PR TITLE
ENHANCEMENT: 'Apply' button for streamlining log filtering in debugging

### DIFF
--- a/src/main/java/com/tibagni/logviewer/filter/FiltersList.java
+++ b/src/main/java/com/tibagni/logviewer/filter/FiltersList.java
@@ -1,6 +1,7 @@
 package com.tibagni.logviewer.filter;
 
 import com.tibagni.logviewer.ServiceLocator;
+import com.tibagni.logviewer.preferences.LogViewerPreferences;
 import com.tibagni.logviewer.theme.LogViewerThemeManager;
 import com.tibagni.logviewer.util.CommonUtils;
 import com.tibagni.logviewer.util.StringUtils;
@@ -26,6 +27,7 @@ public class FiltersList extends JPanel {
   private Map<String, Filter[]> filters;
   private Map<String, FilterUIGroup> filterUIGroups;
   private final LogViewerThemeManager themeManager = ServiceLocator.INSTANCE.getThemeManager();
+  private final LogViewerPreferences userPrefs = ServiceLocator.INSTANCE.getLogViewerPrefs();
 
   public FiltersList(LayoutManager layout, boolean isDoubleBuffered) {
     super(layout, isDoubleBuffered);
@@ -478,7 +480,8 @@ public class FiltersList extends JPanel {
       list.setReorderedListener(this::reorderFilters);
       list.setItemsCheckListener((CheckBoxList.ItemsCheckListener<Filter>) elements -> {
         elements.forEach(f -> f.setApplied(!f.isApplied()));
-        if (listener != null) {
+        // If the user has the preference to apply the filter on check, we notify the listener
+        if (userPrefs.getApplyFilterOnCheck() && listener != null) {
           listener.onFiltersApplied();
         }
         updateActionPaneButtons();

--- a/src/main/java/com/tibagni/logviewer/preferences/LogViewerPreferences.kt
+++ b/src/main/java/com/tibagni/logviewer/preferences/LogViewerPreferences.kt
@@ -13,6 +13,7 @@ interface LogViewerPreferences {
     var preferredTextEditor: File?
     var collapseAllGroupsStartup: Boolean
     var showLineNumbers: Boolean
+    var applyFilterOnCheck: Boolean
 
     fun setAppliedFiltersIndices(group: String, indices: List<Int>)
     fun getAppliedFiltersIndices(group: String): List<Int>
@@ -30,6 +31,7 @@ interface LogViewerPreferences {
         fun onPreferredTextEditorChanged()
         fun onCollapseAllGroupsStartupChanged()
         fun onShowLineNumbersChanged()
+        fun onApplyFiltersOnCheckChanged() {}
     }
 
     abstract class Adapter : Listener {
@@ -43,5 +45,6 @@ interface LogViewerPreferences {
         override fun onPreferredTextEditorChanged() {}
         override fun onCollapseAllGroupsStartupChanged() {}
         override fun onShowLineNumbersChanged() {}
+        override fun onApplyFiltersOnCheckChanged() {}
     }
 }

--- a/src/main/java/com/tibagni/logviewer/preferences/LogViewerPreferencesDialog.java
+++ b/src/main/java/com/tibagni/logviewer/preferences/LogViewerPreferencesDialog.java
@@ -28,6 +28,7 @@ public class LogViewerPreferencesDialog extends JDialog implements ButtonsPane.L
   private static final String PREFERRED_TEXT_EDITOR_ID = "preferred_text_editor";
   private static final String COLLAPSE_ALL_GROUPS_STARTUP_ID = "collapse_all_groups_startup";
   private static final String SHOW_LINE_NUMBERS_ID = "show_line_numbers";
+  private static final String APPLY_FILTER_CHECK_ID = "apply_filter_check";
 
   private ButtonsPane buttonsPane;
   private JPanel contentPane;
@@ -43,6 +44,7 @@ public class LogViewerPreferencesDialog extends JDialog implements ButtonsPane.L
   private JCheckBox showLineNumbersChbx;
   private JTextField preferredEditorPathTxt;
   private JButton preferredEditorPathBtn;
+  private JCheckBox applyFiltersOnCheckChbx;
 
   private JFileChooser filterFolderChooser;
   private JFileChooser logsFolderChooser;
@@ -102,6 +104,9 @@ public class LogViewerPreferencesDialog extends JDialog implements ButtonsPane.L
 
     showLineNumbersChbx.addActionListener(e -> onShowLineNumbersChanged());
     showLineNumbersChbx.setSelected(userPrefs.getShowLineNumbers());
+
+    applyFiltersOnCheckChbx.addActionListener(e -> onApplyFiltersOnCheckChanged());
+    applyFiltersOnCheckChbx.setSelected(userPrefs.getApplyFilterOnCheck());
   }
 
   private void initLogsPathPreference() {
@@ -218,6 +223,14 @@ public class LogViewerPreferencesDialog extends JDialog implements ButtonsPane.L
     dialog.setVisible(true);
   }
 
+  /**
+   * This method is called when the "Apply filters on check" checkbox is toggled.
+   */
+  private void onApplyFiltersOnCheckChanged() {
+    boolean isChecked = applyFiltersOnCheckChbx.getModel().isSelected();
+    saveActions.put(APPLY_FILTER_CHECK_ID, () -> userPrefs.setApplyFilterOnCheck(isChecked));
+  }
+
   private void buildUi() {
     contentPane = new JPanel();
     contentPane.setLayout(new GridBagLayout());
@@ -251,7 +264,7 @@ public class LogViewerPreferencesDialog extends JDialog implements ButtonsPane.L
     final JPanel formPane = new JPanel();
     formPane.setLayout(new FormLayout(
         "fill:d:grow,left:4dlu:noGrow,fill:d:grow,left:4dlu:noGrow,fill:d:grow",
-        "center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow"));
+        "center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow,top:3dlu:noGrow,center:d:grow"));
 
 
     final JLabel lookNFeelLbl = new JLabel();
@@ -326,18 +339,25 @@ public class LogViewerPreferencesDialog extends JDialog implements ButtonsPane.L
     showLineNumbersChbx.setText("");
     formPane.add(showLineNumbersChbx, cc.xy(3, 21));
 
+    final JLabel applyFiltersOnChangeLbl = new JLabel();
+    applyFiltersOnChangeLbl.setText("Apply filters on check");
+    formPane.add(applyFiltersOnChangeLbl, cc.xy(1, 23));
+    applyFiltersOnCheckChbx = new JCheckBox();
+    applyFiltersOnCheckChbx.setText("");
+    formPane.add(applyFiltersOnCheckChbx, cc.xy(3, 23));
+
     final JSeparator sep4 = new JSeparator();
-    formPane.add(sep4, cc.xyw(1, 22, 3, CellConstraints.FILL, CellConstraints.DEFAULT));
+    formPane.add(sep4, cc.xyw(1, 24, 3, CellConstraints.FILL, CellConstraints.DEFAULT));
 
     final JLabel preferredEditorLbl = new JLabel();
     preferredEditorLbl.setText("Preferred text Editor");
-    formPane.add(preferredEditorLbl, cc.xy(1, 23));
+    formPane.add(preferredEditorLbl, cc.xy(1, 25));
     preferredEditorPathTxt = new JTextField();
     preferredEditorPathTxt.setEditable(false);
-    formPane.add(preferredEditorPathTxt, cc.xy(3, 23, CellConstraints.FILL, CellConstraints.DEFAULT));
+    formPane.add(preferredEditorPathTxt, cc.xy(3, 25, CellConstraints.FILL, CellConstraints.DEFAULT));
     preferredEditorPathBtn = new JButton();
     preferredEditorPathBtn.setText("...");
-    formPane.add(preferredEditorPathBtn, cc.xy(5, 23));
+    formPane.add(preferredEditorPathBtn, cc.xy(5, 25));
 
     return formPane;
   }

--- a/src/main/java/com/tibagni/logviewer/preferences/LogViewerPreferencesImpl.kt
+++ b/src/main/java/com/tibagni/logviewer/preferences/LogViewerPreferencesImpl.kt
@@ -18,6 +18,7 @@ object LogViewerPreferencesImpl : LogViewerPreferences {
     /*Visible for Testing*/ const val PREFERRED_TEXT_EDITOR = "preferred_text_editor"
     /*Visible for Testing*/ const val COLLAPSE_ALL_GROUPS_STARTUP = "collapse_all_groups_startup"
     /*Visible for Testing*/ const val SHOW_LINE_NUMBERS = "show_line_numbers"
+    /*Visible for Testing*/ const val REAPPLY_FILTERS_ON_CHANGE = "reapply_filters_on_change"
 
     // Allow changing for tests
     private var preferences = Preferences.userRoot().node(javaClass.name)
@@ -112,6 +113,16 @@ object LogViewerPreferencesImpl : LogViewerPreferences {
         set(show) {
             preferences.putBoolean(SHOW_LINE_NUMBERS, show)
             listeners.forEach { l -> l.onShowLineNumbersChanged() }
+        }
+
+    /**
+     * If true, the filters will be re-applied every time when a checkbox is checked or unchecked.
+     */
+    override var applyFilterOnCheck: Boolean
+        get() = preferences.getBoolean(REAPPLY_FILTERS_ON_CHANGE, true)
+        set(reApply) {
+            preferences.putBoolean(REAPPLY_FILTERS_ON_CHANGE, reApply)
+            listeners.forEach { l -> l.onApplyFiltersOnCheckChanged() }
         }
 
     override fun setAppliedFiltersIndices(group: String, indices: List<Int>) {

--- a/src/test/java/com/tibagni/logviewer/preferences/LogViewerPreferencesImplTests.kt
+++ b/src/test/java/com/tibagni/logviewer/preferences/LogViewerPreferencesImplTests.kt
@@ -449,4 +449,43 @@ class LogViewerPreferencesImplTests {
         verify(mockPrefs, times(1)).put(LogViewerPreferencesImpl.PREFERRED_TEXT_EDITOR, "")
         verify(mockListener, only()).onPreferredTextEditorChanged()
     }
+
+    /**
+     * Tests the applyFilterOnCheck setting
+     * This setting is used to determine if the filters should be applied when the user checks a filter checkbox
+     */
+    @Test
+    fun testSettingApplyFilterOnCheck() {
+        LogViewerPreferencesImpl.applyFilterOnCheck = true
+
+        verify(mockPrefs, times(1)).putBoolean(LogViewerPreferencesImpl.REAPPLY_FILTERS_ON_CHANGE, true)
+        verify(mockListener, only()).onApplyFiltersOnCheckChanged()
+    }
+
+    /**
+     * Tests the applyFilterOnCheck setting
+     * This setting is used to determine if the filters should be applied when the user unchecks a filter checkbox
+     */
+    @Test
+    fun testSettingApplyFilterOnCheck2() {
+        LogViewerPreferencesImpl.applyFilterOnCheck = false
+
+        verify(mockPrefs, times(1)).putBoolean(LogViewerPreferencesImpl.REAPPLY_FILTERS_ON_CHANGE, false)
+        verify(mockListener, only()).onApplyFiltersOnCheckChanged()
+    }
+
+    /**
+     * Tests the applyFilterOnCheck setting
+     * This setting is used to determine if the filters should be applied when the user checks and unchecks a filter checkbox
+     */
+    @Test
+    fun testGettingApplyFilterOnCheck() {
+        `when`(mockPrefs.getBoolean(eq(LogViewerPreferencesImpl.REAPPLY_FILTERS_ON_CHANGE), anyBoolean())).thenReturn(true)
+        val returnedVal = LogViewerPreferencesImpl.applyFilterOnCheck
+
+        verify(mockPrefs, never()).putBoolean(LogViewerPreferencesImpl.REAPPLY_FILTERS_ON_CHANGE, false)
+        verify(mockPrefs, never()).putBoolean(LogViewerPreferencesImpl.REAPPLY_FILTERS_ON_CHANGE, true)
+        verify(mockListener, never()).onApplyFiltersOnCheckChanged()
+        assertEquals(true, returnedVal)
+    }
 }


### PR DESCRIPTION
[Problem]
Debugging with a bug report often requires checking and unchecking filters from different groups, resulting in long filter processing times, reducing productivity. The LogViewer currently lacks an explicit 'Apply' button to apply all changes at once. Users must select multiple filters or press space for their checking status to revert after each change.

[Solution]
- Implemented an 'Apply' button that applies all changes made to the filter and updates filtered logs.
- Added a user setting called ‘Apply filters on check’, allowing users to toggle whether filtering should occur on every check/uncheck of the filter. When disabled, users can use the 'Apply' button after changing their filters, updating the filtered logs. With it enabled, the current behavior is followed, like filtering logs for each change in the filter.

Closes #58